### PR TITLE
Support SQLAlchemy declarative model

### DIFF
--- a/fixture/loadable/sqlalchemy_loadable.py
+++ b/fixture/loadable/sqlalchemy_loadable.py
@@ -230,9 +230,7 @@ class MappedClassMedium(DBLoadableFixture.StorageMediumAdapter):
         
     def save(self, row, column_vals):
         """Save a new object to the session if it doesn't already exist in the session."""
-        obj = self.medium()
-        for c, val in column_vals:
-            setattr(obj, c, val)
+        obj = self.medium(**dict(column_vals))
         if obj not in self.session.new:
             if hasattr(self.session, 'add'):
                 # sqlalchemy 0.5.2+


### PR DESCRIPTION
[Patch taken](https://code.google.com/p/fixture/issues/detail?id=52) from the old issue tracker.

Change SQLAlchemyFixture MappedClassMedium to pass column values to model constructor. This is supported by SQLAlchemy's default constructor and allows us to use declarative model definitions with custom constructor arguments.

Example:

```
class User(Base)
  id = sa.Column(sa.types.Integer, primary_key=True)
  name = sa.Column('name', sa.types.Unicode(100))
  name2 = sa.Column('name', sa.types.Unicode(100))

  def __init__(self, _name):
    self.name = _name
    self.name2 = "Your %s" % (_name,)

class UserData(DataSet):
  class carl_sagan:
    name = u'Carl Sagan'
```
