### PR TITLE
Use the appropriate SQLAlchemy exceptions module

### DIFF
--- a/fixture/loadable/sqlalchemy_loadable.py
+++ b/fixture/loadable/sqlalchemy_loadable.py
@@ -15,6 +15,13 @@ import logging
 log = logging.getLogger('fixture.loadable.sqlalchemy_loadable')
 
 try:
+    # >0.5
+    from sqlalchemy import exc as sqlalchemy_exc
+except ImportError:
+    # <0.5
+    from sqlalchemy import exceptions as sqlalchemy_exc
+
+try:
     from sqlalchemy.orm import sessionmaker, scoped_session
 except ImportError:
     Session = None
@@ -355,7 +362,7 @@ def is_assigned_mapper(obj):
         def is_assigned(obj):
             try:
                 cm = class_mapper(obj)
-            except sqlalchemy.exceptions.InvalidRequestError:
+            except sqlalchemy_exc.InvalidRequestError:
                 return False
             return True
             

--- a/fixture/test/test_loadable/test_sqlalchemy_loadable.py
+++ b/fixture/test/test_loadable/test_sqlalchemy_loadable.py
@@ -521,7 +521,12 @@ class TestTableObjectsExplicitConn(object):
 
 
 def test_fixture_can_be_disposed():
-    from sqlalchemy.exceptions import InvalidRequestError
+    try:
+        # <0.5
+        from sqlalchemy.exceptions import InvalidRequestError
+    except ImportError:
+        # > 0.5
+        from sqlalchemy.exc import InvalidRequestError
     engine = create_engine(conf.LITE_DSN)
     metadata.bind = engine
     metadata.create_all()


### PR DESCRIPTION
In SQLAlchemy 0.8.0+ the alias of `sqlalchemy.exceptions` that pointed to `sqlalchemy.exc` has [finally been removed](http://docs.sqlalchemy.org/en/rel_0_8/changelog/migration_08.html#sqlalchemy-exceptions-has-been-sqlalchemy-exc-for-years).

This causes `fixture` to bomb in the `sqlalchemy_loadable` when determining mappings if there is an error in the mapping definition (say a typo in a relationship's primaryjoin field).  This kinda sucks because it prevents the surfacing of information about the actual error:

```
  File "/home/vagrant/.virtualenvs/api/local/lib/python2.7/site-packages/fixture/loadable/sqlalchemy_loadable.py", line 352, in is_assigned
    except sqlalchemy.exceptions.InvalidRequestError:
AttributeError: 'module' object has no attribute 'exceptions'
```

This fixes that bug and also fixes it in one of the tests.
