### PR TITLE
last_inserted_ids() in sqlalchemy was deprecated by inserted_primary_key...

### DIFF
--- a/fixture/loadable/sqlalchemy_loadable.py
+++ b/fixture/loadable/sqlalchemy_loadable.py
@@ -326,8 +326,8 @@ class TableMedium(DBLoadableFixture.StorageMediumAdapter):
             c = stmt.execute(params)
 
         # In SQLAlchemy 0.8 this changed to a property with another name
-        if hasattr(c, "primary_key"):
-            primary_key = c.primary_key
+        if hasattr(c, "inserted_primary_key"):
+            primary_key = c.inserted_primary_key
         else:
             primary_key = c.last_inserted_ids()
 


### PR DESCRIPTION
... not primary_key
