### PR TITLE
Sets now can be assigned to multi-value columns

### DIFF
--- a/fixture/dataset/dataset.py
+++ b/fixture/dataset/dataset.py
@@ -554,7 +554,7 @@ class DataSet(DataContainer):
                 if isinstance(col_val, Ref):
                     # the .ref attribute
                     continue
-                elif type(col_val) in (types.ListType, types.TupleType):
+                elif type(col_val) in (types.ListType, types.TupleType, set):
                     for c in col_val:
                         if is_rowlike(c):
                             add_ref_from_rowlike(c)

--- a/fixture/loadable/loadable.py
+++ b/fixture/loadable/loadable.py
@@ -267,6 +267,9 @@ class LoadableFixture(Fixture):
             if type(val) in (types.ListType, types.TupleType):
                 # i.e. categories = [python, ruby]
                 setattr(row, name, map(resolve_stored_object, val))
+            elif type(val) is set:
+                # i.e. categories = {python, ruby}
+                setattr(row, name, set(resolve_stored_object(v) for v in val))
             elif is_rowlike(val):
                 # i.e. category = python
                 setattr(row, name, resolved_rowlike(val))


### PR DESCRIPTION
Previously multi-value columns accept only `list` or `tuple` objects.  This patch makes it possible to accept `set` as well.
