### PR TITLE
Support a mix of DB and NDB in the Google EntityMedium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ fixture/examples/pylons_example/addressbook/tests.db
 fixture/examples/pylons_example/addressbook/Paste*
 fixture/examples/django_example/project.db
 fixture/examples/pylons_example/addressbook/testdb.sqlite
+.idea


### PR DESCRIPTION
Google App Engine lets you use a mix of DB and NDB inside the same app and even
allows you to access the same datastore document using both models at
the same time. Because of this, the EntityMedium has been updated to
handle either object based upon ducktyping.

Fixes #5 

I would have also updated the unit tests but the buildout code is so old it no longer works according to the instructions in your readme.
